### PR TITLE
Implement awaitable Report methods.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ jobs:
           if-no-files-found: error
 
   upload-coverage:
-    if: ${{ github.event_name }} != "pull_request"
+    if: ${{ github.event_name != 'pull_request' }}
     name: Upload coverage
     needs: [run-checks, run-tests]
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ report = await client.retrieve(
 await report.to_csv("./async-analytics.csv")
 ```
 
-If you want to analyse this data using additional tools such as *pandas*, you can directly export the report as a DataFrame (note that *pandas* is an optional dependency -- see above):
+If you want to analyse this data using additional tools such as *pandas*, you can directly export the report as a DataFrame (note that *pandas* is an optional dependency -- [see above](#additional-support)):
 
 ```py
 df = report.to_dataframe()

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ report = await client.retrieve(
     dimensions=("country",),
     start_date=dt.date.today() - dt.timedelta(days=7),
 )
-await report.ato_csv("./async-analytics.csv")
+await report.to_csv("./async-analytics.csv")
 ```
 
 If you want to analyse this data using additional tools such as *pandas*, you can directly export the report as a DataFrame (note that *pandas* is an optional dependency -- see above):

--- a/analytix/abc.py
+++ b/analytix/abc.py
@@ -192,7 +192,7 @@ class DynamicReportWriter(metaclass=abc.ABCMeta):
             ][0]
         except IndexError:
             raise RuntimeError(
-                f"You should not manually instantiate this class."
+                "You should not manually instantiate this class."
             ) from None
 
         ctx = stack_data.code_context
@@ -209,8 +209,8 @@ class DynamicReportWriter(metaclass=abc.ABCMeta):
 
     @abc.abstractmethod
     def _run_sync(self) -> None:
-        ...
+        raise NotImplementedError
 
     @abc.abstractmethod
     async def _run_async(self) -> None:
-        ...
+        raise NotImplementedError

--- a/analytix/reports.py
+++ b/analytix/reports.py
@@ -140,7 +140,7 @@ class Report:
 
         return JSONReportWriter(path, data=self.data, indent=indent)
 
-    async def ato_json(self, path: str, *, indent: int = 4) -> None:
+    async def ato_json(self, path: str, *, indent: int = 4) -> JSONReportWriter:
         """Asynchronously write the report data to a JSON file.
 
         Args:
@@ -153,17 +153,7 @@ class Report:
                 with. Defaults to ``4``.
         """
 
-        log.warning(
-            "The `ato_json` method is deprecated - use `await to_json` instead."
-        )
-
-        if not path.endswith(".json"):
-            path += ".json"
-
-        async with aiofiles.open(path, "w") as f:
-            await f.write(json.dumps(self.data, indent=indent))
-
-        log.info(f"Saved report as JSON to {Path(path).resolve()}")
+        return self.to_json(path, indent=indent)
 
     def to_csv(self, path: str, *, delimiter: str = ",") -> CSVReportWriter:
         """Write the report data to a CSV file.
@@ -185,7 +175,7 @@ class Report:
             columns=self.columns,
         )
 
-    async def ato_csv(self, path: str, *, delimiter: str = ",") -> None:
+    async def ato_csv(self, path: str, *, delimiter: str = ",") -> CSVReportWriter:
         """Asynchronously write the report data to a CSV file.
 
         Args:
@@ -198,20 +188,7 @@ class Report:
                 here will save the file as a TSV instead.
         """
 
-        log.warning("The `ato_csv` method is deprecated - use `await to_csv` instead.")
-
-        extension = ".tsv" if delimiter == "\t" else ".csv"
-
-        if not path.endswith(extension):
-            path += extension
-
-        async with aiofiles.open(path, "w") as f:
-            await f.write(f"{delimiter.join(self.columns)}\n")
-            for row in self.data["rows"]:
-                line = delimiter.join(f"{v}" for v in row)
-                await f.write(f"{line}\n")
-
-        log.info(f"Saved report as CSV to {Path(path).resolve()}")
+        return self.to_csv(path, delimiter=delimiter)
 
     def to_excel(self, path: str, *, sheet_name: str = "Analytics") -> None:
         """Write the report data to an Excel spreadsheet.

--- a/analytix/reports.py
+++ b/analytix/reports.py
@@ -126,7 +126,8 @@ class Report:
         return (self._nrows, self._ncolumns)
 
     def to_json(self, path: str, *, indent: int = 4) -> JSONReportWriter:
-        """Write the report data to a JSON file.
+        """Write the report data to a JSON file. If awaited, this
+        method will utilise ``aiofiles`` and run asynchronously.
 
         Args:
             path:
@@ -136,11 +137,16 @@ class Report:
             indent:
                 The amount of indentation the data should be written
                 with. Defaults to ``4``.
+
+        Returns:
+            ``JSONReportWriter``:
+                A dynamic object that allows for awaiting this non async
+                method.
         """
 
         return JSONReportWriter(path, data=self.data, indent=indent)
 
-    async def ato_json(self, path: str, *, indent: int = 4) -> JSONReportWriter:
+    async def ato_json(self, path: str, *, indent: int = 4) -> None:
         """Asynchronously write the report data to a JSON file.
 
         Args:
@@ -153,10 +159,11 @@ class Report:
                 with. Defaults to ``4``.
         """
 
-        return self.to_json(path, indent=indent)
+        await self.to_json(path, indent=indent)
 
-    def to_csv(self, path: str, *, delimiter: str = ",") -> CSVReportWriter:
-        """Write the report data to a CSV file.
+    def to_csv(self, path: str, *, delimiter: str = ",") -> DynamicReportWriter:
+        """Write the report data to a CSV file. If awaited, this
+        method will utilise ``aiofiles`` and run asynchronously.
 
         Args:
             path:
@@ -166,6 +173,11 @@ class Report:
             delimiter:
                 The delimiter to use. Defaults to a comma. Passing a tab
                 here will save the file as a TSV instead.
+
+        Returns:
+            ``CSVReportWriter``:
+                A dynamic object that allows for awaiting this non async
+                method.
         """
 
         return CSVReportWriter(
@@ -175,7 +187,7 @@ class Report:
             columns=self.columns,
         )
 
-    async def ato_csv(self, path: str, *, delimiter: str = ",") -> CSVReportWriter:
+    async def ato_csv(self, path: str, *, delimiter: str = ",") -> None:
         """Asynchronously write the report data to a CSV file.
 
         Args:
@@ -188,7 +200,7 @@ class Report:
                 here will save the file as a TSV instead.
         """
 
-        return self.to_csv(path, delimiter=delimiter)
+        await self.to_csv(path, delimiter=delimiter)
 
     def to_excel(self, path: str, *, sheet_name: str = "Analytics") -> None:
         """Write the report data to an Excel spreadsheet.

--- a/analytix/reports.py
+++ b/analytix/reports.py
@@ -28,7 +28,6 @@
 
 from __future__ import annotations
 
-import inspect
 import json
 import logging
 import typing as t
@@ -38,7 +37,7 @@ import aiofiles
 
 import analytix
 from analytix import errors
-from analytix.abc import ReportType
+from analytix.abc import DynamicReportWriter, ReportType
 
 if t.TYPE_CHECKING:
     import pandas as pd
@@ -46,108 +45,58 @@ if t.TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 
-class DynamicReportWriter:
-
-    __slots__ = ("_function", "_path", "_data", "_indent", "_delimiter", "_columns")
-
-    def __init__(
-        self,
-        function: str,
-        *,
-        path: str,
-        data: dict[t.Any, t.Any],
-        indent: int = 4,
-        delimiter: str = ",",
-        columns: list[t.Any] = [],
-    ) -> None:
-        self._function = function
-        self._path = path
-        self._data = data
-        self._indent = indent
-        self._delimiter = delimiter
-        self._columns = columns
-        stack = inspect.stack()
-
-        try:
-            stack_data = [
-                f
-                for f in stack
-                if f.code_context is not None and stack[1].function in f.code_context[0]
-            ][0]
-        except IndexError:
-            raise RuntimeError(
-                f"You should not manually instantiate this class."
-            ) from None
-
-        ctx = stack_data.code_context
-        assert ctx
-        if not any(word == "await" for word in ctx[0].split()):
-            self._run_sync()
-
-    def __await__(self) -> t.Generator[t.Any, None, DynamicReportWriter]:
-        async def inner() -> DynamicReportWriter:
-            await self._run_async()
-            return self
-
-        return inner().__await__()
-
-    def _raise(self) -> t.NoReturn:
-        raise TypeError(
-            f"{self.__class__.__name__!r} only works with the "
-            "`Report.to_csv` and `Report.to_json` methods."
-        )
+class JSONReportWriter(DynamicReportWriter):
+    __slots__ = ()
 
     def _run_sync(self) -> None:
-        if self._function == "to_csv":
-            extension = ".tsv" if self._delimiter == "\t" else ".csv"
+        if not self._path.endswith(".json"):
+            self._path += ".json"
 
-            if not self._path.endswith(extension):
-                self._path += extension
+        with open(self._path, "w") as f:
+            json.dump(self._data, f, indent=self._indent)
 
-            with open(self._path, "w") as f:
-                f.write(f"{self._delimiter.join(self._columns)}\n")
-                for row in self._data["rows"]:
-                    line = self._delimiter.join(f"{v}" for v in row)
-                    f.write(f"{line}\n")
-
-            return log.info(f"Saved report as CSV to {Path(self._path).resolve()}")
-
-        elif self._function == "to_json":
-            if not self._path.endswith(".json"):
-                self._path += ".json"
-
-            with open(self._path, "w") as f:
-                json.dump(self._data, f, indent=self._indent)
-
-            return log.info(f"Saved report as JSON to {Path(self._path).resolve()}")
-
-        self._raise()
+        return log.info(f"Saved report as JSON to {Path(self._path).resolve()}")
 
     async def _run_async(self) -> None:
-        if self._function == "to_csv":
-            extension = ".tsv" if self._delimiter == "\t" else ".csv"
+        if not self._path.endswith(".json"):
+            self._path += ".json"
 
-            if not self._path.endswith(extension):
-                self._path += extension
+        async with aiofiles.open(self._path, "w") as f:
+            await f.write(json.dumps(self._data, indent=self._indent))
 
-            async with aiofiles.open(self._path, "w") as f:
-                await f.write(f"{self._delimiter.join(self._columns)}\n")
-                for row in self._data["rows"]:
-                    line = self._delimiter.join(f"{v}" for v in row)
-                    await f.write(f"{line}\n")
+        return log.info(f"Saved report as JSON to {Path(self._path).resolve()}")
 
-            return log.info(f"Saved report as CSV to {Path(self._path).resolve()}")
 
-        elif self._function == "to_json":
-            if not self._path.endswith(".json"):
-                self._path += ".json"
+class CSVReportWriter(DynamicReportWriter):
+    __slots__ = ()
 
-            async with aiofiles.open(self._path, "w") as f:
-                await f.write(json.dumps(self._data, indent=self._indent))
+    def _run_sync(self) -> None:
+        extension = ".tsv" if self._delimiter == "\t" else ".csv"
 
-            return log.info(f"Saved report as JSON to {Path(self._path).resolve()}")
+        if not self._path.endswith(extension):
+            self._path += extension
 
-        self._raise()
+        with open(self._path, "w") as f:
+            f.write(f"{self._delimiter.join(self._columns)}\n")
+            for row in self._data["rows"]:
+                line = self._delimiter.join(f"{v}" for v in row)
+                f.write(f"{line}\n")
+
+        return log.info(f"Saved report as CSV to {Path(self._path).resolve()}")
+
+    async def _run_async(self) -> None:
+        extension = ".tsv" if self._delimiter == "\t" else ".csv"
+
+        if not self._path.endswith(extension):
+            self._path += extension
+
+        async with aiofiles.open(self._path, "w") as f:
+            await f.write(f"{self._delimiter.join(self._columns)}\n")
+            for row in self._data["rows"]:
+                line = self._delimiter.join(f"{v}" for v in row)
+                await f.write(f"{line}\n")
+
+        return log.info(f"Saved report as CSV to {Path(self._path).resolve()}")
 
 
 class Report:
@@ -176,7 +125,7 @@ class Report:
 
         return (self._nrows, self._ncolumns)
 
-    def to_json(self, path: str, *, indent: int = 4) -> DynamicReportWriter:
+    def to_json(self, path: str, *, indent: int = 4) -> JSONReportWriter:
         """Write the report data to a JSON file.
 
         Args:
@@ -189,7 +138,7 @@ class Report:
                 with. Defaults to ``4``.
         """
 
-        return DynamicReportWriter("to_json", data=self.data, path=path, indent=indent)
+        return JSONReportWriter(path, data=self.data, indent=indent)
 
     async def ato_json(self, path: str, *, indent: int = 4) -> None:
         """Asynchronously write the report data to a JSON file.
@@ -216,7 +165,7 @@ class Report:
 
         log.info(f"Saved report as JSON to {Path(path).resolve()}")
 
-    def to_csv(self, path: str, *, delimiter: str = ",") -> DynamicReportWriter:
+    def to_csv(self, path: str, *, delimiter: str = ",") -> CSVReportWriter:
         """Write the report data to a CSV file.
 
         Args:
@@ -229,10 +178,9 @@ class Report:
                 here will save the file as a TSV instead.
         """
 
-        return DynamicReportWriter(
-            "to_csv",
+        return CSVReportWriter(
+            path,
             data=self.data,
-            path=path,
             delimiter=delimiter,
             columns=self.columns,
         )

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -297,7 +297,7 @@ def test_retrieve_version_check(client, request_data):
         )
 
         with mock.patch.object(Analytics, "check_for_updates") as mock_check:
-            mock_check.return_value == "9999.9.9"
+            mock_check.return_value = "9999.9.9"
 
             report = client.retrieve(
                 dimensions=("day",),

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -387,3 +387,25 @@ def test_retrieve_with_refresh(client, tokens, tokens_dict):
                 )
 
     os.remove(JSON_OUTPUT_PATH)
+
+
+def test_retrieve_with_no_authorisation(client, tokens, request_data):
+    client._tokens = tokens
+
+    with mock.patch.object(httpx.Client, "get") as mock_get:
+        mock_get.return_value = httpx.Response(
+            status_code=200,
+            request=mock.Mock(),
+            json=request_data,
+        )
+
+        with mock.patch.object(Analytics, "authorise") as mock_auth:
+            mock_auth.return_value = tokens
+            client.retrieve(
+                force_authorisation=True,
+                skip_refresh_check=True,
+                skip_update_check=True,
+            )
+
+            mock_auth.assert_called_once()
+            mock_get.assert_called_once()

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -268,8 +268,10 @@ def request_data():
         return json.load(f)
 
 
-def test_retrieve(client, request_data):
+def test_retrieve(client, request_data, tokens):
     with mock.patch.object(httpx.Client, "get") as mock_get:
+        client._tokens = tokens
+
         mock_get.return_value = httpx.Response(
             status_code=200,
             request=mock.Mock(),
@@ -288,8 +290,10 @@ def test_retrieve(client, request_data):
         assert isinstance(report.type, TimeBasedActivity)
 
 
-def test_retrieve_version_check(client, request_data):
+def test_retrieve_version_check(client, request_data, tokens):
     with mock.patch.object(httpx.Client, "get") as mock_get:
+        client._tokens = tokens
+
         mock_get.return_value = httpx.Response(
             status_code=200,
             request=mock.Mock(),
@@ -310,8 +314,10 @@ def test_retrieve_version_check(client, request_data):
             assert isinstance(report.type, TimeBasedActivity)
 
 
-def test_retrieve_no_validate(client, request_data):
+def test_retrieve_no_validate(client, request_data, tokens):
     with mock.patch.object(httpx.Client, "get") as mock_get:
+        client._tokens = tokens
+
         mock_get.return_value = httpx.Response(
             status_code=200,
             request=mock.Mock(),
@@ -331,7 +337,9 @@ def test_retrieve_no_validate(client, request_data):
         assert isinstance(report.type, TimeBasedActivity)
 
 
-def test_retrieve_with_refresh_check(client, request_data):
+def test_retrieve_with_refresh_check(client, request_data, tokens):
+    client._tokens = tokens
+
     with mock.patch.object(httpx.Client, "get") as mock_get:
         mock_get.return_value = httpx.Response(
             status_code=200,

--- a/tests/test_async_analytics.py
+++ b/tests/test_async_analytics.py
@@ -400,3 +400,25 @@ async def test_retrieve_with_refresh(client, tokens, tokens_dict):
                 )
 
     os.remove(JSON_OUTPUT_PATH)
+
+
+async def test_retrieve_with_no_authorisation(client, tokens, request_data):
+    client._tokens = tokens
+
+    with mock.patch.object(httpx.AsyncClient, "get") as mock_get:
+        mock_get.return_value = httpx.Response(
+            status_code=200,
+            request=mock.Mock(),
+            json=request_data,
+        )
+
+        with mock.patch.object(AsyncAnalytics, "authorise") as mock_auth:
+            mock_auth.return_value = tokens
+            await client.retrieve(
+                force_authorisation=True,
+                skip_refresh_check=True,
+                skip_update_check=True,
+            )
+
+            mock_auth.assert_called_once()
+            mock_get.assert_called_once()

--- a/tests/test_async_analytics.py
+++ b/tests/test_async_analytics.py
@@ -268,8 +268,10 @@ def request_data():
         return json.load(f)
 
 
-async def test_retrieve(client, request_data):
+async def test_retrieve(client, request_data, tokens):
     with mock.patch.object(httpx.AsyncClient, "get") as mock_get:
+        client._tokens = tokens
+
         mock_get.return_value = httpx.Response(
             status_code=200,
             request=mock.Mock(),
@@ -288,8 +290,10 @@ async def test_retrieve(client, request_data):
         assert isinstance(report.type, TimeBasedActivity)
 
 
-async def test_retrieve_version_check(client, request_data):
+async def test_retrieve_version_check(client, request_data, tokens):
     with mock.patch.object(httpx.AsyncClient, "get") as mock_get:
+        client._tokens = tokens
+
         mock_get.return_value = httpx.Response(
             status_code=200,
             request=mock.Mock(),
@@ -310,8 +314,10 @@ async def test_retrieve_version_check(client, request_data):
             assert isinstance(report.type, TimeBasedActivity)
 
 
-async def test_retrieve_no_validate(client, request_data):
+async def test_retrieve_no_validate(client, request_data, tokens):
     with mock.patch.object(httpx.AsyncClient, "get") as mock_get:
+        client._tokens = tokens
+
         mock_get.return_value = httpx.Response(
             status_code=200,
             request=mock.Mock(),
@@ -331,8 +337,10 @@ async def test_retrieve_no_validate(client, request_data):
         assert isinstance(report.type, TimeBasedActivity)
 
 
-async def test_retrieve_with_refresh_check(client, request_data):
+async def test_retrieve_with_refresh_check(client, request_data, tokens):
     with mock.patch.object(httpx.AsyncClient, "get") as mock_get:
+        client._tokens = tokens
+
         mock_get.return_value = httpx.Response(
             status_code=200,
             request=mock.Mock(),

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -37,7 +37,7 @@ import pytest
 import analytix
 from analytix import data, errors
 from analytix.report_types import TimeBasedActivity
-from analytix.reports import Report
+from analytix.reports import CSVReportWriter, JSONReportWriter, Report
 from tests.paths import (
     CSV_OUTPUT_PATH,
     EXCEL_OUTPUT_PATH,
@@ -373,3 +373,13 @@ def test_to_excel_no_openpyxl(report):
             str(exc.value)
             == "some necessary libraries are not installed (hint: pip install openpyxl)"
         )
+
+
+def test_report_writers_with_bad_stack():
+    with pytest.raises(RuntimeError) as e:
+        JSONReportWriter("test.json", data={"Hello": "Goodbye"})
+        assert "You should not manually instantiate this class." == str(e)
+
+    with pytest.raises(RuntimeError) as e:
+        CSVReportWriter("test.csv", data={"Hello": "Goodbye"})
+        assert "You should not manually instantiate this class." == str(e)

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -96,7 +96,17 @@ def test_to_json(report, request_data):
     os.remove(JSON_OUTPUT_PATH)
 
 
-async def test_to_json_async(report, request_data):
+async def test_await_to_json(report, request_data):
+    await report.to_json(str(JSON_OUTPUT_PATH))
+    assert JSON_OUTPUT_PATH.is_file()
+
+    with open(JSON_OUTPUT_PATH) as f:
+        assert json.load(f) == request_data
+
+    os.remove(JSON_OUTPUT_PATH)
+
+
+async def test_deprecated_ato_json(report, request_data):
     await report.ato_json(str(JSON_OUTPUT_PATH))
     assert JSON_OUTPUT_PATH.is_file()
 
@@ -116,7 +126,17 @@ def test_to_json_no_extension(report, request_data):
     os.remove(JSON_OUTPUT_PATH)
 
 
-async def test_to_json_async_no_extension(report, request_data):
+async def test_await_to_json_no_extension(report, request_data):
+    await report.to_json(str(JSON_OUTPUT_PATH)[:-5])
+    assert JSON_OUTPUT_PATH.is_file()
+
+    with open(JSON_OUTPUT_PATH) as f:
+        assert json.load(f) == request_data
+
+    os.remove(JSON_OUTPUT_PATH)
+
+
+async def test_deprecated_ato_json_no_extension(report, request_data):
     await report.ato_json(str(JSON_OUTPUT_PATH)[:-5])
     assert JSON_OUTPUT_PATH.is_file()
 
@@ -142,7 +162,17 @@ def test_to_csv(report, mock_csv_data):
     os.remove(CSV_OUTPUT_PATH)
 
 
-async def test_to_csv_async(report, mock_csv_data):
+async def test_await_to_csv(report, mock_csv_data):
+    await report.to_csv(str(CSV_OUTPUT_PATH))
+    assert CSV_OUTPUT_PATH.is_file()
+
+    with open(CSV_OUTPUT_PATH) as f:
+        assert f.read() == mock_csv_data
+
+    os.remove(CSV_OUTPUT_PATH)
+
+
+async def test_deprecated_ato_csv(report, mock_csv_data):
     await report.ato_csv(str(CSV_OUTPUT_PATH))
     assert CSV_OUTPUT_PATH.is_file()
 
@@ -162,7 +192,17 @@ def test_to_csv_no_extension(report, mock_csv_data):
     os.remove(CSV_OUTPUT_PATH)
 
 
-async def test_to_csv_async_no_extension(report, mock_csv_data):
+async def test_await_to_csv_no_extension(report, mock_csv_data):
+    await report.to_csv(str(CSV_OUTPUT_PATH)[:-4])
+    assert CSV_OUTPUT_PATH.is_file()
+
+    with open(CSV_OUTPUT_PATH) as f:
+        assert f.read() == mock_csv_data
+
+    os.remove(CSV_OUTPUT_PATH)
+
+
+async def test_deprecated_ato_csv_no_extension(report, mock_csv_data):
     await report.ato_csv(str(CSV_OUTPUT_PATH)[:-4])
     assert CSV_OUTPUT_PATH.is_file()
 
@@ -182,7 +222,17 @@ def test_to_tsv(report, mock_csv_data):
     os.remove(TSV_OUTPUT_PATH)
 
 
-async def test_to_tsv_async(report, mock_csv_data):
+async def test_await_to_tsv(report, mock_csv_data):
+    await report.to_csv(str(TSV_OUTPUT_PATH), delimiter="\t")
+    assert TSV_OUTPUT_PATH.is_file()
+
+    with open(TSV_OUTPUT_PATH) as f:
+        assert f.read() == mock_csv_data.replace(",", "\t")
+
+    os.remove(TSV_OUTPUT_PATH)
+
+
+async def test_deprecated_ato_tsv(report, mock_csv_data):
     await report.ato_csv(str(TSV_OUTPUT_PATH), delimiter="\t")
     assert TSV_OUTPUT_PATH.is_file()
 
@@ -202,7 +252,17 @@ def test_to_tsv_no_extension(report, mock_csv_data):
     os.remove(TSV_OUTPUT_PATH)
 
 
-async def test_to_tsv_async_no_extension(report, mock_csv_data):
+async def test_await_to_tsv_no_extension(report, mock_csv_data):
+    await report.to_csv(str(TSV_OUTPUT_PATH)[:-4], delimiter="\t")
+    assert TSV_OUTPUT_PATH.is_file()
+
+    with open(TSV_OUTPUT_PATH) as f:
+        assert f.read() == mock_csv_data.replace(",", "\t")
+
+    os.remove(TSV_OUTPUT_PATH)
+
+
+async def test_deprecated_ato_tsv_no_extension(report, mock_csv_data):
     await report.ato_csv(str(TSV_OUTPUT_PATH)[:-4], delimiter="\t")
     assert TSV_OUTPUT_PATH.is_file()
 


### PR DESCRIPTION
## Summary

This pull request adds the ability to await the `Report.to_csv` and `Report.to_json` methods.
It does this by returning an awaitable class, that will call the sync versions of these functions if it is not awaited.

## Additions

- `analytix.reports.DynamicReportWriter` class.
- Tests for awaiting these methods.

## Changes
- The return type of these methods from `None` to `DynamicReportWriter`.
    * This object is intended to be discarded by the end user.
    * Should `DynamicReportWriter` implement `__eq__` and `__bool__` to preserve consistency with a `None` return type?
- Deprecated `Report.ato_csv` and `Report.ato_json`.

## Related issues

Closes #26 