### PR TITLE
Do not show port if is port 80

### DIFF
--- a/analytix/analytics.py
+++ b/analytix/analytics.py
@@ -206,7 +206,7 @@ class Analytics:
             rd_addr = redirect_uris[0]
         else:
             ru = redirect_uris[-1]
-            rd_addr = f"{ru}:{port}"
+            rd_addr = f"{ru}:{port}" if port != 80 else ru
 
         url, _ = oauth.auth_url_and_state(self.secrets, rd_addr)
         code = self._mcp(url) if self.legacy_auth else self._ws(url, ru, port)


### PR DESCRIPTION
Port 80 is the default port for websites and shouldn't be shown in the URLs.